### PR TITLE
Fix jsonapi_deserialize example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ class MyController < ActionController::Base
   def update
     model = MyModel.find(params[:id])
 
-    if model.update(jsonapi_deserialize(only: [:attr1, :rel_one]))
+    if model.update(jsonapi_deserialize(params, only: [:attr1, :rel_one]))
       render jsonapi: model
     else
       render jsonapi_errors: model.errors, status: :unprocessable_entity

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -106,7 +106,7 @@ module JSONAPI
 
     # Checks if an object is a collection
     #
-    # Stollen from [FastJsonapi::ObjectSerializer], instance method.
+    # Stolen from [FastJsonapi::ObjectSerializer], instance method.
     #
     # @param resource [Object] to check
     # @param force_is_collection [NilClass] flag to overwrite


### PR DESCRIPTION
Hi! I recently found this repo (via [jsonapi.org](https://jsonapi.org/implementations/#server-libraries-ruby)) while evaluating JSON:API options for a new Rails 6 app and since I was already in the source I thought I'd take care of the doc error in the `jsonapi_deserialize` example noted by @dgavey in issue #3. 

Thanks for the bundle, I'm finding it a very useful way to conveniently tie together a few gems I was already considering using. 

Resolves https://github.com/stas/jsonapi.rb/issues/3