### PR TITLE
Array pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in jsonapi.gemspec
 gemspec
 
-gem 'jsonapi-rspec', git: 'https://github.com/stas/jsonapi-rspec.git'
+gem 'jsonapi-rspec', git: 'https://github.com/jsonapi-rb/jsonapi-rspec.git'

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -45,21 +45,32 @@ RSpec.describe UsersController, type: :request do
             .to eq(CGI.unescape(params.to_query))
         end
 
-        context 'even when it is an array' do
-          let(:params) { { sort: '-created_at', as_list: true } }
-
-          it do
-            expect(response).to have_http_status(:ok)
-            expect(response_json['data'].size).to eq(3)
-          end
-        end
-
         context 'on page 2 out of 3' do
+          let(:as_list) { }
           let(:params) do
             {
               page: { number: 2, size: 1 },
-              sort: '-created_at'
-            }
+              sort: '-created_at',
+              as_list: as_list
+            }.reject { |_k, _v| _v.blank? }
+          end
+
+          context 'on an array of resources' do
+            let(:as_list) { true }
+
+            it do
+              expect(response).to have_http_status(:ok)
+              expect(response_json['data'].size).to eq(1)
+              expect(response_json['data'][0]).to have_id(second_user.id.to_s)
+
+              expect(response_json['meta']['pagination']).to eq(
+                'current' => 2,
+                'first' => 1,
+                'prev' => 1,
+                'next' => 3,
+                'last' => 3
+              )
+            end
           end
 
           it do


### PR DESCRIPTION
## What is the current behavior?

#4 describes two issues:
 * The array pagination meta is rendering the wrong cur/prev/next pages due to the original resources being already paginated
 * The paginated array is off by one due to wrong math

## What is the new behavior?

We are caching the original array size and using that to calculate the meta. The math is also fixed now.

@jf @petronius I will appreciate any feedback. I'll try to release the fix asap.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
