### PR TITLE
Fix paging beyond end of array, when `resources[(offset)..(offset + limit - 1)]` may be nil

### DIFF
--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -18,6 +18,8 @@ module JSONAPI
       else
         original_size = resources.size
         resources = resources[(offset)..(offset + limit - 1)]
+        resources ||= []
+
         # Cache the original resources size to be used for pagination meta
         resources.instance_variable_set(:@original_size, original_size)
       end


### PR DESCRIPTION
## What is the current behavior?

Continuing the discussion from #4, it looks like we still need one more fix/test for arrays. #15 was good but we need something to handle the case for when we attempt to page beyond what an array can give us. Does this make sense?

So as an example:
```
resources = [1,2,3,4,5]
offset = 20
limit = 10

resources[(offset)..(offset + limit - 1)]
=> nil
```

When we page beyond the end of the array, the next line, https://github.com/stas/jsonapi.rb/blob/fa5a0bc4b7bbfd4c2c6c6f2133ee342179a8f9de/lib/jsonapi/pagination.rb#L22 fails.

## What is the new behavior?

Paging beyond the end of an array does not fail.

Comments and feedback welcome. Apologies for not following the format with the checklist; I have tests, but I'm not entirely sure about ticking the CI/CD box.