### PR TITLE
More elegant and expressive fix for #16

### DIFF
--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -17,8 +17,7 @@ module JSONAPI
         resources = resources.offset(offset).limit(limit)
       else
         original_size = resources.size
-        resources = resources[(offset)..(offset + limit - 1)]
-        resources ||= []
+        resources = resources[(offset)..(offset + limit - 1)] || []
 
         # Cache the original resources size to be used for pagination meta
         resources.instance_variable_set(:@original_size, original_size)


### PR DESCRIPTION
Sorry, but I just realized that there was a much more expressive and clearer way to communicate the fix than what I coded earlier. Apologies for the noise, but thought this was worth rewriting.