### PR TITLE
Remove some Rails-ism from pagination module.

### DIFF
--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -30,13 +30,13 @@ module JSONAPI
     #
     # @return [Array]
     def jsonapi_pagination(resources)
-      links = { self: request.base_url + request.original_fullpath }
+      links = { self: request.base_url + request.fullpath }
       pagination = jsonapi_pagination_meta(resources)
 
       return links if pagination.blank?
 
       original_params = params.except(
-        *request.path_parameters.keys.map(&:to_s)
+        *jsonapi_path_parameters.keys.map(&:to_s)
       ).to_unsafe_h.with_indifferent_access
 
       original_params[:page] ||= {}
@@ -97,6 +97,15 @@ module JSONAPI
       num = [1, pagination[:number].to_f.to_i].max
 
       [(num - 1) * per_page, per_page, num]
+    end
+
+    # Fallback to Rack's parsed query string when Rails is not available
+    #
+    # @return [Hash]
+    def jsonapi_path_parameters
+      return request.path_parameters if request.respond_to?(:path_parameters)
+
+      request.send(:parse_query, request.query_string, '&;')
     end
   end
 end


### PR DESCRIPTION
The idea is to use as much as possible Rack's API instead of Rails. 

@banduk would you be kind to give this branch a try please. If you find anything else, I'll be happy to take care of it. Thanks again!

## What is the current behavior?

Pagination module fails on non-Rails (Grape/Rack) implementations.

## What is the new behavior?

Pagination will fallback to Rack's API where Rails is not available.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
