### PR TITLE
Add resource total count to pagination meta

### DIFF
--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -82,6 +82,8 @@ module JSONAPI
         numbers[:last] = last_page
       end
 
+      numbers[:total] = total
+
       numbers
     end
 

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UsersController, type: :request do
     it do
       expect(response_json['data'].size).to eq(0)
       expect(response_json['meta'])
-        .to eq('many' => true, 'pagination' => { 'current' => 1 })
+        .to eq('many' => true, 'pagination' => { 'current' => 1, 'total' => 0 })
     end
 
     context 'with users' do
@@ -68,7 +68,8 @@ RSpec.describe UsersController, type: :request do
                 'first' => 1,
                 'prev' => 1,
                 'next' => 3,
-                'last' => 3
+                'last' => 3,
+                'total' => 3
               )
             end
           end
@@ -83,8 +84,9 @@ RSpec.describe UsersController, type: :request do
               'first' => 1,
               'prev' => 1,
               'next' => 3,
-              'last' => 3
-            )
+              'last' => 3,
+              'total' => 3
+          )
 
             expect(response_json).to have_link(:self)
             expect(response_json).to have_link(:prev)
@@ -122,8 +124,9 @@ RSpec.describe UsersController, type: :request do
             expect(response_json['meta']['pagination']).to eq(
               'current' => 3,
               'first' => 1,
-              'prev' => 2
-            )
+              'prev' => 2,
+              'total' => 3
+          )
 
             expect(response_json).to have_link(:self)
             expect(response_json).to have_link(:prev)
@@ -161,7 +164,8 @@ RSpec.describe UsersController, type: :request do
               expect(response_json['meta']['pagination']).to eq(
                 'current' => 5,
                 'first' => 1,
-                'prev' => 4
+                'prev' => 4,
+                'total' => 3
               )
             end
           end
@@ -173,7 +177,8 @@ RSpec.describe UsersController, type: :request do
             expect(response_json['meta']['pagination']).to eq(
               'current' => 5,
               'first' => 1,
-              'prev' => 4
+              'prev' => 4,
+              'total' => 3
             )
 
             expect(response_json).to have_link(:self)
@@ -209,7 +214,8 @@ RSpec.describe UsersController, type: :request do
             expect(response_json['meta']['pagination']).to eq(
               'current' => 1,
               'next' => 2,
-              'last' => 3
+              'last' => 3,
+              'total' => 3
             )
 
             expect(response_json).not_to have_link(:prev)


### PR DESCRIPTION
## What is the current behavior?

Currently it’s not possible to determine the total number of resources within paginated results.

## What is the new behavior?

Since the total is already calculated, it’s a small change to go ahead and include it.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
