### PR TITLE
Update fast_jsonapi dependency

### DIFF
--- a/jsonapi.rb.gemspec
+++ b/jsonapi.rb.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fast_jsonapi', '~> 1.5'
+  spec.add_dependency 'jsonapi-serializer', '~> 2.0'
   spec.add_dependency 'ransack'
   spec.add_dependency 'rack'
 

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -43,7 +43,7 @@ module JSONAPI
         resource = [resource] unless many
 
         return JSONAPI::ErrorSerializer.new(resource, options)
-          .serialized_json unless resource.is_a?(ActiveModel::Errors)
+          .serializable_hash.to_json unless resource.is_a?(ActiveModel::Errors)
 
         errors = []
         model = resource.instance_variable_get('@base')
@@ -68,7 +68,7 @@ module JSONAPI
 
         JSONAPI::ActiveModelErrorSerializer.new(
           errors, params: { model: model, model_serializer: model_serializer }
-        ).serialized_json
+        ).serializable_hash.to_json
       end
     end
 
@@ -100,7 +100,7 @@ module JSONAPI
           serializer_class = JSONAPI::Rails.serializer_class(resource, many)
         end
 
-        serializer_class.new(resource, options).serialized_json
+        serializer_class.new(resource, options).serializable_hash.to_json
       end
     end
 


### PR DESCRIPTION
This changes the fast_jsonapi dependency from Netflix' unmaintained one to the [jsonapi-serializer](https://github.com/jsonapi-serializer/jsonapi-serializer) fork, which is actively maintained.