### PR TITLE
Add Count of Records to Pagination

### DIFF
--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -82,6 +82,10 @@ module JSONAPI
         numbers[:last] = last_page
       end
 
+      if total.present?
+        numbers[:records] = total
+      end
+
       numbers
     end
 

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -17,7 +17,13 @@ RSpec.describe UsersController, type: :request do
     it do
       expect(response_json['data'].size).to eq(0)
       expect(response_json['meta'])
-        .to eq('many' => true, 'pagination' => { 'current' => 1 })
+        .to eq(
+          'many' => true,
+          'pagination' => {
+            'current' => 1,
+            'records' => 0
+          }
+        )
     end
 
     context 'with users' do
@@ -68,7 +74,8 @@ RSpec.describe UsersController, type: :request do
                 'first' => 1,
                 'prev' => 1,
                 'next' => 3,
-                'last' => 3
+                'last' => 3,
+                'records' => 3
               )
             end
           end
@@ -83,7 +90,8 @@ RSpec.describe UsersController, type: :request do
               'first' => 1,
               'prev' => 1,
               'next' => 3,
-              'last' => 3
+              'last' => 3,
+              'records' => 3
             )
 
             expect(response_json).to have_link(:self)
@@ -122,7 +130,8 @@ RSpec.describe UsersController, type: :request do
             expect(response_json['meta']['pagination']).to eq(
               'current' => 3,
               'first' => 1,
-              'prev' => 2
+              'prev' => 2,
+              'records' => 3
             )
 
             expect(response_json).to have_link(:self)
@@ -161,7 +170,8 @@ RSpec.describe UsersController, type: :request do
               expect(response_json['meta']['pagination']).to eq(
                 'current' => 5,
                 'first' => 1,
-                'prev' => 4
+                'prev' => 4,
+                'records' => 3
               )
             end
           end
@@ -173,7 +183,8 @@ RSpec.describe UsersController, type: :request do
             expect(response_json['meta']['pagination']).to eq(
               'current' => 5,
               'first' => 1,
-              'prev' => 4
+              'prev' => 4,
+              'records' => 3
             )
 
             expect(response_json).to have_link(:self)
@@ -209,7 +220,8 @@ RSpec.describe UsersController, type: :request do
             expect(response_json['meta']['pagination']).to eq(
               'current' => 1,
               'next' => 2,
-              'last' => 3
+              'last' => 3,
+              'records' => 3
             )
 
             expect(response_json).not_to have_link(:prev)


### PR DESCRIPTION
## What is the current behavior?

Currently, the pagination doesn't return the total number of records, which can be required on the client-side to generate pagination metadata, e.g. `1-10 of 29 widgets`.

This is referenced in #21 and #23 already, and while I agree that the `total` name proposed in #21 is confusing (could be total of pages?), the proposed solution there effectively replicates the existing functionality in `/lib/jsonapi/pagination.rb`.

## What is the new behavior?

Added a `records` key to the pagination, that is the total number of records being paginated.

Hopefully, this name is less confusing, and succinctly describes itself.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
