### PR TITLE
Log errors in Rails log

### DIFF
--- a/lib/jsonapi/errors.rb
+++ b/lib/jsonapi/errors.rb
@@ -34,6 +34,7 @@ module JSONAPI
     # @param exception [Exception] instance to handle
     # @return [String] JSONAPI error response
     def render_jsonapi_internal_server_error(exception)
+      log_error(exception)
       error = { status: '500', title: Rack::Utils::HTTP_STATUS_CODES[500] }
       render jsonapi_errors: [error], status: :internal_server_error
     end
@@ -65,6 +66,20 @@ module JSONAPI
       }
 
       render jsonapi_errors: [error], status: :unprocessable_entity
+    end
+
+    # Method to facilitate error logging
+    #
+    # @param exception [Exception] instance to handle
+    # @return [Boolean] Always returns true
+    def log_error(exception)
+      logger = defined?(::Rails) && ::Rails.logger
+      return unless logger
+
+      message = +"\n#{exception.class} (#{exception.message}):\n"
+      message << exception.annotated_source_code.to_s if exception.respond_to?(:annotated_source_code)
+      message << "  " << exception.backtrace.join("\n  ")
+      logger.fatal("#{message}\n\n")
     end
   end
 end


### PR DESCRIPTION
## What is the current behavior?

Errors when rendering out JSONAPI responses are entirely swallowed.

## What is the new behavior?

When developing in Rails, and even when running in production, I would
like to be able to see backtraces and errors in my logs.

This snippet of code is taken from the Rails source code, where it
appears in multiple non-reusable private methods. It will give the
familiar Rails feel when looking at one's log.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)

I haven't added a test because a) the change is quite minimal and b) I don't know how to stub the `::Rails` constant in a spec without that leaking to other parts of the test suite.

- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
