### PR TITLE
Total count and configurable default per_page

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ class MyController < ActionController::Base
       render jsonapi: paginated
     end
   end
+
 end
 ```
 
@@ -305,6 +306,15 @@ use the `jsonapi_pagination_meta` method:
     { pagination: pagination } if pagination.present?
   end
 
+```
+
+If you want to change the default number of items per page, use the
+`jsonapi_page_size` method:
+
+```ruby
+  def jsonapi_page_size
+    30
+  end
 ```
 ### Deserialization
 

--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -93,14 +93,20 @@ module JSONAPI
     #
     # @return [Array] with the offset, limit and the current page number
     def jsonapi_pagination_params
-      def_per_page = self.class.const_get(:JSONAPI_PAGE_SIZE).to_i
 
       pagination = params[:page].try(:slice, :number, :size) || {}
       per_page = pagination[:size].to_f.to_i
-      per_page = def_per_page if per_page < 1
+      per_page = jsonapi_page_size if per_page < 1
       num = [1, pagination[:number].to_f.to_i].max
 
       [(num - 1) * per_page, per_page, num]
+    end
+
+    # Retrieves the default page size
+    #
+    # @return [Integer]
+    def jsonapi_page_size
+      self.class.const_get(:JSONAPI_PAGE_SIZE).to_i
     end
 
     # Fallback to Rack's parsed query string when Rails is not available

--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -42,7 +42,7 @@ module JSONAPI
       original_params[:page] = original_params[:page].dup || {}
       original_url = request.base_url + request.path + '?'
 
-      pagination.each do |page_name, number|
+      pagination.delete_if{ |k, _v| k == :records }.each do |page_name, number|
         original_params[:page][:number] = number
         links[page_name] = original_url + CGI.unescape(
           original_params.to_query

--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -97,7 +97,7 @@ module JSONAPI
 
       pagination = params[:page].try(:slice, :number, :size) || {}
       per_page = pagination[:size].to_f.to_i
-      per_page = def_per_page if per_page > def_per_page || per_page < 1
+      per_page = def_per_page if per_page < 1
       num = [1, pagination[:number].to_f.to_i].max
 
       [(num - 1) * per_page, per_page, num]

--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -42,7 +42,9 @@ module JSONAPI
       original_params[:page] = original_params[:page].dup || {}
       original_url = request.base_url + request.path + '?'
 
-      pagination.delete_if{ |k, _v| k == :records }.each do |page_name, number|
+      pagination.each do |page_name, number|
+        next if page_name == :records
+
         original_params[:page][:number] = number
         links[page_name] = original_url + CGI.unescape(
           original_params.to_query
@@ -93,7 +95,6 @@ module JSONAPI
     #
     # @return [Array] with the offset, limit and the current page number
     def jsonapi_pagination_params
-
       pagination = params[:page].try(:slice, :number, :size) || {}
       per_page = pagination[:size].to_f.to_i
       per_page = jsonapi_page_size if per_page < 1


### PR DESCRIPTION
## What is the current behavior?

Default per-page is 30 and set using a constant. Pagination meta does not include total number of records.

## What is the new behavior?

Implementers may now configure the default per-page by defining a method. Total number of records is included in the pagination meta.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
