### PR TITLE
Use `#size` instead of `#count` for pagination

### DIFF
--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -63,7 +63,7 @@ module JSONAPI
       numbers = { current: page }
 
       if resources.respond_to?(:unscope)
-        total = resources.unscope(:limit, :offset, :order).count()
+        total = resources.unscope(:limit, :offset, :order).size
       else
         # Try to fetch the cached size first
         total = resources.instance_variable_get(:@original_size)


### PR DESCRIPTION
## What is the current behavior?

The `Pagination` module uses `#count` to calculate the total number of resources. AR's `#count` always executes an SQL `COUNT`.

## What is the new behavior?

Use AR's `#size` instead, which checks if the records of the AR relation have already been loaded and only executes a `COUNT` if truly necessary.

See https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-size

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
