### PR TITLE
Handle Rails 6.1 ActiveModel::Error#detail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.4, 2.7]
-        rails: [5, 6]
+        rails: ['5', '6.0', '6']
         exclude:
           - ruby: 2.4
             rails: 6

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -55,8 +55,18 @@ module JSONAPI
           model_serializer = JSONAPI::Rails.serializer_class(model, false)
         end
 
-        details = resource.messages
-        details = resource.details if resource.respond_to?(:details)
+        details = {}
+        if ::Rails::VERSION::MAJOR >= 6 && ::Rails::VERSION::MINOR >= 1
+          resource.map do |error|
+            attr = error.attribute
+            details[attr] ||= []
+            details[attr] << error.detail.merge(message: error.message)
+          end
+        elsif resource.respond_to?(:details)
+          details = resource.details
+        else
+          details = resource.messages
+        end
 
         details.each do |error_key, error_hashes|
           error_hashes.each do |error_hash|

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -56,8 +56,13 @@ RSpec.describe NotesController, type: :request do
           .to eq(Rack::Utils::HTTP_STATUS_CODES[422])
         expect(response_json['errors'][0]['source'])
           .to eq('pointer' => '/data/relationships/user')
-        expect(response_json['errors'][0]['detail'])
-          .to eq('User can\'t be blank')
+        if Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1
+          expect(response_json['errors'][0]['detail'])
+            .to eq('User must exist')
+        else
+          expect(response_json['errors'][0]['detail'])
+            .to eq('User can\'t be blank')
+        end
       end
 
       context 'required by validations' do


### PR DESCRIPTION
## What is the current behavior?

Starting with Rails 6.1 `ActiveModel::Error` is an actual class:

> Active Model's errors are now objects with an interface that allows
> your application to more easily handle and interact with errors thrown
> by models. The feature[1] includes a query interface, enables more
> precise testing, and access to error details.
>
> [1] rails/rails#32313

As a result of this `resource.details` looks slightly different than in
previous versions and [notably doesn't contain `:message`](https://github.com/rails/rails/blob/2a7ff0a5f54979b14b19f827c99295297dda411d/activemodel/lib/active_model/error.rb#L149) anymore, if
`object.errors.add(:something, message: 'some error')` was used to specify a validation error.

[This causes the json payload for validation errors not to contain the specified message anymore and the spec for `Rails 6.1` to fail.](https://github.com/stas/jsonapi.rb/runs/1541994498?check_suite_focus=true#step:4:346) 

From the test suite:
https://github.com/stas/jsonapi.rb/blob/3a685a766e12fd5be9176af7e2a54c5c2a7f7a62/spec/dummy.rb#L133

Running `rspec ./spec/errors_spec.rb:71`

https://github.com/stas/jsonapi.rb/blob/3a685a766e12fd5be9176af7e2a54c5c2a7f7a62/lib/jsonapi/rails.rb#L59

Rails 6.0:
```
{
  :title=>[{:error=>:invalid, :value=>"BAD_TITLE"},
           {:error=>{:message=>"has typos"}}],
  :quantity=>[{:error=>:less_than, :value=>109, :count=>100}]
}
```

Rails 6.1:
```
{
  :title=>[{:error=>:invalid, :value=>"BAD_TITLE"},
           {:error=>:invalid}],
  :quantity=>[{:error=>:less_than, :value=>100, :count=>100}]
}
```

## What is the new behavior?

1. The patch addresses this change by merging the `error.message` into `error.detail` yielding:

```
{
  :title=>[{:error=>:invalid, :value=>"BAD_TITLE", :message=>"is invalid"},
           {:error=>:invalid, :message=>"has typos"}],
  :quantity=>[{:error=>:less_than, :value=>106, :count=>100, :message=>"must be less than 100"}]
}
```

As a result the returned json payload contains the intended validation error message again.

2. Due to this change, the message for a missing required field (and possibly other validations) changes from `"x can't be blank"` to `"x must exist"` 

3. I also added Rails `6.0` specifically to the test matrix since this breaking change was introduced with 6.1.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
