### PR TITLE
always call jsonapi_page_size method on pagination enabled requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,12 +308,14 @@ use the `jsonapi_pagination_meta` method:
 
 ```
 
-If you want to change the default number of items per page, use the
+If you want to change the default number of items per page, or define a custom logic to handle page size, use the
 `jsonapi_page_size` method:
 
 ```ruby
-  def jsonapi_page_size
-    30
+  def jsonapi_page_size(pagination_params)
+    per_page = pagination_params[:size].to_f.to_i
+    per_page = 30 if per_page > 30
+    per_page
   end
 ```
 ### Deserialization

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ use the `jsonapi_pagination_meta` method:
 
 ```
 
-If you want to change the default number of items per page, or define a custom logic to handle page size, use the
+If you want to change the default number of items per page or define a custom logic to handle page size, use the
 `jsonapi_page_size` method:
 
 ```ruby

--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -96,7 +96,7 @@ module JSONAPI
     # @return [Array] with the offset, limit and the current page number
     def jsonapi_pagination_params
       pagination = params[:page].try(:slice, :number, :size) || {}
-      per_page = jsonapi_page_size(pagination[:size].to_i.to_f)
+      per_page = jsonapi_page_size(pagination)
       num = [1, pagination[:number].to_f.to_i].max
 
       [(num - 1) * per_page, per_page, num]
@@ -104,13 +104,17 @@ module JSONAPI
 
     # Retrieves the default page size
     #
-    # @param per_page_param [Integer] per Page extracted from parmas hash
+    # @param per_page_param [Hash] Page size extracted from parmas hash
     #
     # @return [Integer]
-    def jsonapi_page_size(per_page_param)
-      per_page_param < 1 ?
-        self.class.const_get(:JSONAPI_PAGE_SIZE).to_i :
-        per_page_param
+    def jsonapi_page_size(pagination_params)
+      per_page = pagination_params[:size].to_f.to_i
+
+      return self.class
+              .const_get(:JSONAPI_PAGE_SIZE)
+              .to_i if per_page < 1
+
+      per_page
     end
 
     # Fallback to Rack's parsed query string when Rails is not available

--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -104,7 +104,9 @@ module JSONAPI
 
     # Retrieves the default page size
     #
-    # @param per_page_param [Hash] Page size extracted from parmas hash
+    # @param per_page_param [Hash] opts the paginations params
+    # @option opts [String] :number the page number requested
+    # @option opts [String] :size the page size requested
     #
     # @return [Integer]
     def jsonapi_page_size(pagination_params)

--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -96,8 +96,7 @@ module JSONAPI
     # @return [Array] with the offset, limit and the current page number
     def jsonapi_pagination_params
       pagination = params[:page].try(:slice, :number, :size) || {}
-      per_page = pagination[:size].to_f.to_i
-      per_page = jsonapi_page_size if per_page < 1
+      per_page = jsonapi_page_size(pagination[:size].to_i.to_f)
       num = [1, pagination[:number].to_f.to_i].max
 
       [(num - 1) * per_page, per_page, num]
@@ -105,9 +104,13 @@ module JSONAPI
 
     # Retrieves the default page size
     #
+    # @param per_page_param [Integer] per Page extracted from parmas hash
+    #
     # @return [Integer]
-    def jsonapi_page_size
-      self.class.const_get(:JSONAPI_PAGE_SIZE).to_i
+    def jsonapi_page_size(per_page_param)
+      per_page_param < 1 ?
+        self.class.const_get(:JSONAPI_PAGE_SIZE).to_i :
+        per_page_param
     end
 
     # Fallback to Rack's parsed query string when Rails is not available


### PR DESCRIPTION
## What is the current behavior?

related to issue https://github.com/stas/jsonapi.rb/issues/37

if you set the params `page[size]` in the query, `jsonapi_page_size` is not called and `page[size]` is used to determine  the page size of the paginated response.

## What is the new behavior?

always call the module method `jsonapi_page_size` and pass the value of the query param `page[size]` to the method to define the page size of the paginated response. Fallback to `JSONAPI_PAGE_SIZE` if `page[size]` is lower than 1 or not present in the query string at all.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
