### PR TITLE
ActiveModel error serializer improvements

### DIFF
--- a/lib/jsonapi/active_model_error_serializer.rb
+++ b/lib/jsonapi/active_model_error_serializer.rb
@@ -50,12 +50,12 @@ module JSONAPI
         message = errors_object.generate_message(
           error_key, nil, error_hash[:error]
         )
-      elsif error_hash[:error].present?
+      elsif error_hash[:error].present? && error_hash[:error].is_a?(Symbol)
         message = errors_object.generate_message(
           error_key, error_hash[:error], error_hash
         )
       else
-        message = error_hash[:message]
+        message = error_hash[:message] || error_hash[:error]
       end
 
       errors_object.full_message(error_key, message)

--- a/lib/jsonapi/active_model_error_serializer.rb
+++ b/lib/jsonapi/active_model_error_serializer.rb
@@ -52,7 +52,7 @@ module JSONAPI
       elsif error_key == :base
         { pointer: "/data" }
       else
-        { pointer: '' }
+        { pointer: nil }
       end
     end
   end

--- a/lib/jsonapi/active_model_error_serializer.rb
+++ b/lib/jsonapi/active_model_error_serializer.rb
@@ -49,6 +49,8 @@ module JSONAPI
         { pointer: "/data/attributes/#{error_key}" }
       elsif rels.include?(error_key)
         { pointer: "/data/relationships/#{error_key}" }
+      elsif error_key == :base
+        { pointer: "/data" }
       else
         { pointer: '' }
       end

--- a/lib/jsonapi/active_model_error_serializer.rb
+++ b/lib/jsonapi/active_model_error_serializer.rb
@@ -3,12 +3,34 @@ require 'jsonapi/error_serializer'
 module JSONAPI
   # [ActiveModel::Errors] serializer
   class ActiveModelErrorSerializer < ErrorSerializer
-    attribute :status do
-      '422'
+    class << self
+      ##
+      # Get the status code to render for the serializer, considering an eventual
+      # status provided through the serializer parameters
+      #
+      # @param params [Hash]
+      #     The serializer parameters
+      #
+      # @return [Integer]
+      #     The status code to use
+      def status_code(params)
+        case params[:status]
+        when Symbol
+          Rack::Utils::SYMBOL_TO_STATUS_CODE[params[:status]]
+        when Integer
+          params[:status]
+        else
+          422
+        end
+      end
     end
 
-    attribute :title do
-      Rack::Utils::HTTP_STATUS_CODES[422]
+    attribute :status do |_, params|
+      status_code(params).to_s
+    end
+
+    attribute :title do |_, params|
+      Rack::Utils::HTTP_STATUS_CODES[status_code(params)]
     end
 
     attribute :code do |object|

--- a/lib/jsonapi/active_model_error_serializer.rb
+++ b/lib/jsonapi/active_model_error_serializer.rb
@@ -5,8 +5,10 @@ module JSONAPI
   class ActiveModelErrorSerializer < ErrorSerializer
     class << self
       ##
-      # Get the status code to render for the serializer, considering an
-      # eventual status provided through the serializer parameters
+      # Get the status code to render for the serializer
+      #
+      # This considers an optional status provided through the serializer
+      # parameters, as either a symbol or a number.
       #
       # @param params [Hash]
       #     The serializer parameters
@@ -72,7 +74,7 @@ module JSONAPI
       elsif rels.include?(error_key)
         { pointer: "/data/relationships/#{error_key}" }
       elsif error_key == :base
-        { pointer: "/data" }
+        { pointer: '/data' }
       else
         { pointer: nil }
       end

--- a/lib/jsonapi/active_model_error_serializer.rb
+++ b/lib/jsonapi/active_model_error_serializer.rb
@@ -5,8 +5,8 @@ module JSONAPI
   class ActiveModelErrorSerializer < ErrorSerializer
     class << self
       ##
-      # Get the status code to render for the serializer, considering an eventual
-      # status provided through the serializer parameters
+      # Get the status code to render for the serializer, considering an
+      # eventual status provided through the serializer parameters
       #
       # @param params [Hash]
       #     The serializer parameters

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -62,8 +62,21 @@ module JSONAPI
             details[attr] ||= []
             details[attr] << error.detail.merge(message: error.message)
           end
-        elsif resource.respond_to?(:details)
-          details = resource.details
+        elsif resource.respond_to?(:details) && resource.respond_to?(:messages)
+          resource.details.each do |attr, problems|
+            problems.each_with_index do |error, index|
+              details[attr] ||= []
+
+              if error[:error].is_a?(Hash)
+                current = error[:error].dup
+                current[:error] ||= :invalid
+
+                details[attr] << current
+              else
+                details[attr] << error.merge(message: resource.messages[attr][index])
+              end
+            end
+          end
         else
           details = resource.messages
         end

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -79,7 +79,7 @@ module JSONAPI
 
         JSONAPI::Rails.serializer_to_json(
           JSONAPI::ActiveModelErrorSerializer.new(
-            errors, params: { model: model, model_serializer: model_serializer }
+            errors, params: { model: model, model_serializer: model_serializer, status: options[:status] }
           )
         )
       end

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -73,7 +73,8 @@ module JSONAPI
 
                 details[attr] << current
               else
-                details[attr] << error.merge(message: resource.messages[attr][index])
+                message = resource.messages[attr][index]
+                details[attr] << error.merge(message: message)
               end
             end
           end
@@ -92,7 +93,11 @@ module JSONAPI
 
         JSONAPI::Rails.serializer_to_json(
           JSONAPI::ActiveModelErrorSerializer.new(
-            errors, params: { model: model, model_serializer: model_serializer, status: options[:status] }
+            errors, params: {
+              model:            model,
+              model_serializer: model_serializer,
+              status:           options[:status]
+            }
           )
         )
       end

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -43,7 +43,10 @@ class Note < ActiveRecord::Base
 
   # Provide a validation adding an error to the model's base
   def title_check
-    errors.add(:base, :model_invalid, errors: 'The record has an unacceptable title.') if title == 'n/a'
+    return unless title == 'n/a'
+
+    message = 'The record has an unacceptable title.'
+    errors.add(:base, :model_invalid, errors: message)
   end
 
   def deletable?

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -43,7 +43,7 @@ class Note < ActiveRecord::Base
 
   # Provide a validation adding an error to the model's base
   def title_check
-    errors.add(:base, :invalid) if title == 'n/a'
+    errors.add(:base, :model_invalid, errors: 'The record has an unacceptable title.') if title == 'n/a'
   end
 
   def deletable?

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -36,7 +36,13 @@ end
 class Note < ActiveRecord::Base
   validates_format_of :title, without: /BAD_TITLE/
   validates_numericality_of :quantity, less_than: 100, if: :quantity?
+  validate :title_check
   belongs_to :user, required: true
+
+  # Provide a validation adding an error to the model's base
+  def title_check
+    errors.add(:base, :invalid) if title == 'n/a'
+  end
 end
 
 class CustomNoteSerializer

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -186,4 +186,41 @@ RSpec.describe NotesController, type: :request do
       end
     end
   end
+
+  describe 'DELETE /nodes/:id' do
+    let(:note)    { create_note }
+    let(:note_id) { note.id }
+    let(:user)    { note.user }
+    let(:user_id) { user.id }
+
+    context 'with a random note' do
+      before { delete(note_path(note_id), headers: jsonapi_headers) }
+
+      it { expect(response).to have_http_status(:no_content) }
+    end
+
+    context 'with a lovely note' do
+      let(:errors) do
+        {
+          'errors' => [
+            {
+              'code'   => 'cant_delete_lovely_notes',
+              'detail' => "Can't delete lovely notes",
+              'source' => { 'pointer' => '/data' },
+              'status' => '409',
+              'title'  => 'Conflict'
+            }
+          ]
+        }
+      end
+
+      before do
+        note.update(title: 'Lovely')
+        delete(note_path(note_id), headers: jsonapi_headers)
+      end
+
+      it { expect(response).to have_http_status(:conflict) }
+      it { expect(response_json).to match(errors) }
+    end
+  end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -56,13 +56,8 @@ RSpec.describe NotesController, type: :request do
           .to eq(Rack::Utils::HTTP_STATUS_CODES[422])
         expect(response_json['errors'][0]['source'])
           .to eq('pointer' => '/data/relationships/user')
-        if Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1
-          expect(response_json['errors'][0]['detail'])
-            .to eq('User must exist')
-        else
-          expect(response_json['errors'][0]['detail'])
-            .to eq('User can\'t be blank')
-        end
+        expect(response_json['errors'][0]['detail'])
+          .to eq('User must exist')
       end
 
       context 'required by validations' do
@@ -151,7 +146,7 @@ RSpec.describe NotesController, type: :request do
           expect(response_json['errors'][0]['source'])
               .to eq('pointer' => '/data')
           expect(response_json['errors'][0]['detail'])
-            .to eq('is invalid')
+            .to eq('Validation failed: The record has an unacceptable title.')
         end
       end
     end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -133,6 +133,27 @@ RSpec.describe NotesController, type: :request do
             .to eq('pointer' => '/data/attributes/title')
         end
       end
+
+      context 'with a validation error on the class' do
+        let(:params) do
+          payload = note_params.dup
+          payload[:data][:attributes][:title] = 'n/a'
+          payload
+        end
+
+        it do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_json['errors'].size).to eq(1)
+          expect(response_json['errors'][0]['status']).to eq('422')
+          expect(response_json['errors'][0]['code']).to include('invalid')
+          expect(response_json['errors'][0]['title'])
+            .to eq(Rack::Utils::HTTP_STATUS_CODES[422])
+          expect(response_json['errors'][0]['source'])
+              .to eq('pointer' => '/data')
+          expect(response_json['errors'][0]['detail'])
+            .to eq('is invalid')
+        end
+      end
     end
 
     context 'with a bad note ID' do


### PR DESCRIPTION
## What is the current behavior?

The `JSONAPI::ActiveModelErrorSerializer` does not support a (response) status provided to the error render.
It also does not handle serializing ActiveModel errors consistently for Rails versions 5, 6 and 6.1.
Last but not least, the source pointer for errors on the model's base is not right.

## What is the new behavior?

A status provided to an error serializer is now honored:

```ruby
  respond_to do |format|
    format.jsonapi { render jsonapi_errors: record.errors, status: :conflict } 
  end
```

This would render the `status` member of the error response with `'409'`

With an error on a model's base the source pointer rendered is correct now.
```ruby
...
errors.add(:base, :model_invalid, errors: 'The record has an unacceptable title.')
```
This would return a 
```ruby
{ errors: [ { source: { pointer: '/data' }, status: ...
```

Finally, all Rails versions starting with 5 are rendering the error responses consistently. For example, an empty but required `belongs_to :user` relationship would have rendered as `User can't be blank` for Rails 5+ and 6.0, but as `User must exist` for Rails 6.1. This is now `User must exist` consistently. Errors with only a message and no symbol are handled consistently as well now.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
