### PR TITLE
Allow filtering by scope

### DIFF
--- a/lib/jsonapi/filtering.rb
+++ b/lib/jsonapi/filtering.rb
@@ -62,7 +62,7 @@ module JSONAPI
           to_filter = to_filter.split(',')
         end
 
-        if predicates.any? && (field_names - allowed_fields).empty?
+        if (field_names - allowed_fields).empty?
           filtered[requested_field] = to_filter
         end
       end

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -32,7 +32,7 @@ end
 class User < ActiveRecord::Base
   has_many :notes
 
-  scope :created_before, ->(date) { where("created_at < ?", date) }
+  scope :created_before, ->(date) { where('created_at < ?', date) }
 
   def self.ransackable_scopes(_auth_object = nil)
     [:created_before]

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -31,6 +31,12 @@ end
 
 class User < ActiveRecord::Base
   has_many :notes
+
+  scope :created_before, ->(date) { where("created_at < ?", date) }
+
+  def self.ransackable_scopes(_auth_object = nil)
+    [:created_before]
+  end
 end
 
 class Note < ActiveRecord::Base
@@ -83,7 +89,7 @@ class UsersController < ActionController::Base
   def index
     allowed_fields = [
       :first_name, :last_name, :created_at,
-      :notes_created_at, :notes_quantity
+      :notes_created_at, :notes_quantity, :created_before
     ]
     options = { sort_with_expressions: true }
 

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -96,6 +96,29 @@ RSpec.describe UsersController, type: :request do
           expect(response_json['data'][0]).to have_id(second_user.id.to_s)
         end
       end
+
+      context 'returns users filtered by scope' do
+        let(:params) do
+          third_user.update(created_at: '2013-01-01')
+
+          {
+            filter: { created_before: '2013-02-01' }
+          }
+        end
+
+        fit 'ensures ransack scopes are working properly' do
+          ransack = User.ransack({ created_before: '2013-02-01' })
+          expected_sql = 'SELECT "users".* FROM "users" WHERE '\
+                         '(created_at < \'2013-02-01\')'
+          expect(ransack.result.to_sql).to eq(expected_sql)
+        end
+
+        fit 'should return only' do
+          expect(response).to have_http_status(:ok)
+          expect(response_json['data'].size).to eq(1)
+          expect(response_json['data'][0]).to have_id(third_user.id.to_s)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What is the current behavior?

jsonapi.rb will filter out filtering terms that refer to a scope defined on the searchable model.

I've build on a fantastic failing spec by @fluxsaas - thank you!

## What is the new behavior?

This allows the user of jsonapi.rb to specify scopes that are marked as ransackable on the resource being queried. 

Scopes do not have a predicate, and this just removes the predicate check. No API changes, really.

## Related PRs and issues 

Should fix #42 

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
