### PR TITLE
Fix deprecation warning with Content-Type header without modification

### DIFF
--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -37,7 +37,7 @@ module JSONAPI
     # @return [NilClass]
     def self.add_errors_renderer!
       ActionController::Renderers.add(:jsonapi_errors) do |resource, options|
-        self.content_type ||= Mime[:jsonapi]
+        self.content_type = Mime[:jsonapi] if self.media_type.nil?
 
         many = JSONAPI::Rails.is_collection?(resource, options[:is_collection])
         resource = [resource] unless many
@@ -90,7 +90,7 @@ module JSONAPI
     # @return [NilClass]
     def self.add_renderer!
       ActionController::Renderers.add(:jsonapi) do |resource, options|
-        self.content_type ||= Mime[:jsonapi]
+        self.content_type = Mime[:jsonapi] if self.media_type.nil?
 
         JSONAPI_METHODS_MAPPING.to_a[0..1].each do |opt, method_name|
           next unless respond_to?(method_name, true)


### PR DESCRIPTION
## What is the current behavior?

> DEPRECATION WARNING: Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from block (2 levels) in index at /app/app/controllers/api/v1/users_controller.rb:33)

## System configuration

Rails version: 6.0.4

Ruby version: 2.7.3

## Checklist

Please make sure the following requirements are complete:

- [x] All automated checks pass (CI/CD)
