### PR TITLE
Fix where grouped resources will return a hash which causing error

### DIFF
--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -16,7 +16,7 @@ module JSONAPI
       if resources.respond_to?(:offset)
         resources = resources.offset(offset).limit(limit)
       else
-        original_size = resources.size
+        original_size = resources.length
         resources = resources[(offset)..(offset + limit - 1)] || []
 
         # Cache the original resources size to be used for pagination meta
@@ -65,11 +65,11 @@ module JSONAPI
       numbers = { current: page }
 
       if resources.respond_to?(:unscope)
-        total = resources.unscope(:limit, :offset, :order).size
+        total = resources.unscope(:limit, :offset, :order).length
       else
         # Try to fetch the cached size first
         total = resources.instance_variable_get(:@original_size)
-        total ||= resources.size
+        total ||= resources.length
       end
 
       last_page = [1, (total.to_f / limit).ceil].max


### PR DESCRIPTION
## What is the current behavior?

Fix https://github.com/stas/jsonapi.rb/issues/60, where on grouped resources `jsonapi_pagination_meta` will trigger an error, because `.size` on grouped resources will return a `hash`

## What is the new behavior?

Replace `.size` to `.length` which will always return integer

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
features)
- [x] All automated checks pass (CI/CD)
