### PR TITLE
Raise unless Ransack ignore_unknown_conditions?

### DIFF
--- a/lib/jsonapi/filtering.rb
+++ b/lib/jsonapi/filtering.rb
@@ -17,6 +17,9 @@ module JSONAPI
           .detect_and_strip_from_string!(field_name)
         predicates << Ransack::Predicate.named(predicate)
       end
+      unless predicates.present? || Ransack.options[:ignore_unknown_conditions]
+        raise ArgumentError, "No valid predicates for #{requested_field}"
+      end
 
       [field_name.split(/_and_|_or_/), predicates.reverse]
     end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -22,6 +22,30 @@ RSpec.describe UsersController, type: :request do
         expect(predicates[1].name).to eq('eq')
       end
     end
+
+    context 'with an invalidate predicate' do
+      context 'with default configuration' do
+        it 'does not return any predicates' do
+          attributes, predicates = JSONAPI::Filtering
+            .extract_attributes_and_predicates('attr1_eqx')
+          expect(attributes).to eq(['attr1_eqx'])
+          expect(predicates.size).to eq(0)
+        end
+      end
+      context 'with ignore_unknown_conditions as false' do
+        before do
+          Ransack.configure { |c| c.ignore_unknown_conditions = false }
+        end
+        after do
+          Ransack.configure { |c| c.ignore_unknown_conditions = true }
+        end
+        it 'raises an error' do
+          expect do
+            JSONAPI::Filtering.extract_attributes_and_predicates('attr1_eqx')
+          end.to raise_error ArgumentError
+        end
+      end
+    end
   end
 
   describe 'GET /users' do


### PR DESCRIPTION
## What is the current behavior?

https://github.com/stas/jsonapi.rb/issues/62

## What is the new behavior?

It allows to use the `Ransack` configuration property `ignore_unkown_conditions` with the same semantics as in Ransack.
A disadvantage of this solution is that `Ransack` so far has been a dependency of `jsonapi.rb`, and not necessarily of the projects which use `Jsonapi.rb`.  Somehow it could be considered a co-dependency of `jsonapi.rb`, but that is not up to me.

Another solution would be to add a configuration object to `jsonapi.rb`.

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
