### PR TITLE
add symbolize keys option to deserializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ The `jsonapi_deserialize` helper accepts the following options:
  * `except`: returns exclusively attributes/relationship which are not in the list
  * `polymorphic`: will add and detect the `_type` attribute and class to the
    defined list of polymorphic relationships
+ * `symbolize_keys`: returns hash with symbolized keys
 
 This functionality requires support for _inflections_. If your project uses
 `active_support` or `rails` you don't need to do anything. Alternatively, we will

--- a/lib/jsonapi/deserialization.rb
+++ b/lib/jsonapi/deserialization.rb
@@ -44,7 +44,7 @@ module JSONAPI
 
       # Transform keys and any option values.
       options = options.as_json
-      ['only', 'except', 'polymorphic'].each do |opt_name|
+      ['only', 'except', 'polymorphic', 'symbolize_keys'].each do |opt_name|
         opt_value = options[opt_name]
         options[opt_name] = Array(opt_value).map(&:to_s) if opt_value
       end
@@ -77,7 +77,11 @@ module JSONAPI
         end
       end
 
-      parsed
+      if options['symbolize_keys']
+        parsed.symbolize_keys
+      else
+        parsed
+      end
     end
   end
 end

--- a/spec/deserialization_spec.rb
+++ b/spec/deserialization_spec.rb
@@ -83,5 +83,16 @@ RSpec.describe JSONAPI::Deserialization do
         )
       end
     end
+
+
+    context 'with `symbolize_keys`' do
+      it do
+        expect(
+          jsonapi_deserialize.call(
+            document, symbolize_keys: true
+          )
+        ).to match(jsonapi_deserialize.call(document).symbolize_keys)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is the current behavior?

At the moment, the call to the `jsonapi_deserialize` method returns hash with string keys

## What is the new behavior?

Method will provide new option `symbolize_key` which user can set to true and the returned hash will be with symbolized keys

## Checklist

Please make sure the following requirements are complete:

+ [x] Tests for the changes have been added (for bug fixes / features)
+ [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
+ [x] All automated checks pass (CI/CD)