### PR TITLE
Remove unneeded SQL query when determining serializer class.

### DIFF
--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -136,8 +136,15 @@ module JSONAPI
     #
     # @return [Class]
     def self.serializer_class(resource, is_collection)
-      klass = resource.class
-      klass = resource.first.class if is_collection
+      klass = if is_collection
+        if defined?(ActiveRecord::Relation) && resource.respond_to?(:model)
+          resource.model
+        else
+          resource.first.class
+        end
+      else
+        resource.class
+      end
 
       "#{klass.name}Serializer".constantize
     end


### PR DESCRIPTION
While experimenting with the gem I noticed that I was seeing two SQL
queries that were almost identical except one was limited to a single
result. I tracked it down to the `serializer_class` method which was
calling `resource.first` in order to determine the class name of the
collection of resources.

This is necessary if `resource` is an Array, but if it's an
ActiveRecord::Relation, we can call `model` directly on the `resource`
to get the class name.

I've seen elsewhere where you mention you don't want to rely on Rails'
behavior, so I did this in a way that if ActiveRecord::Relation isn't
defined it will fallback to the previous behavior.

I don't believe additional tests are necessary as there already exist
tests that flip `as_list` true and false which will exercise this
change.
