### PR TITLE
Use is_a?(Enumerable) instead of respond_to?(:size) to detect collections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,14 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.7, '3.0']
-        rails: ['5', '6.0', '6']
+        ruby: [2.6, '3.0', '3.1']
+        rails: [5, 6, 7]
         exclude:
-          - ruby: 2.4
-            rails: 6
+          - ruby: '2.6'
+            rails: 7
           - ruby: '3.0'
+            rails: 5
+          - ruby: '3.1'
             rails: 5
 
     steps:
@@ -31,7 +33,6 @@ jobs:
         rm -rf Gemfile.lock
         sudo apt-get update
         sudo apt-get install libsqlite3-dev
-        echo $RAILS_VERSION | grep -q '4' && export SQLITE3_VERSION='~> 1.3.6'
-        echo $RAILS_VERSION | grep -q '4' && RUBOCOP_VERSION='~> 0.77'
+        echo $RAILS_VERSION | grep -q '5' && export SQLITE3_VERSION='~> 1.3.6'
         bundle
         bundle exec rake

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The available features include:
    [sparse fields](https://jsonapi.org/format/#fetching-sparse-fieldsets))
  * [filtering](https://jsonapi.org/format/#fetching-filtering) and
    [sorting](https://jsonapi.org/format/#fetching-sorting) of the data
-   (powered by Ransack)
+   (powered by Ransack, soft-dependency)
  * [pagination](https://jsonapi.org/format/#fetching-pagination) support
 
 ## But how?
@@ -230,6 +230,8 @@ end
 to filter and sort over a collection of records.
 The support is pretty extended and covers also relationships and composite
 matchers.
+
+Please add `ransack` to your `Gemfile` in order to benefit from this functionality!
 
 Here's an example:
 

--- a/Rakefile
+++ b/Rakefile
@@ -30,5 +30,5 @@ else
   task(qa: ['qa:docs', 'qa:code'])
 end
 
-RSpec::Core::RakeTask.new(spec: :qa)
-task(default: :spec)
+RSpec::Core::RakeTask.new(:spec)
+task(default: %w[qa spec])

--- a/jsonapi.rb.gemspec
+++ b/jsonapi.rb.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'jsonapi-serializer'
-  spec.add_dependency 'ransack'
   spec.add_dependency 'rack'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rails', ENV['RAILS_VERSION']
+  spec.add_development_dependency 'ransack'
   spec.add_development_dependency 'sqlite3', ENV['SQLITE3_VERSION']
   spec.add_development_dependency 'ffaker'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/jsonapi.rb.gemspec
+++ b/jsonapi.rb.gemspec
@@ -24,8 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rails', ENV['RAILS_VERSION']
   spec.add_development_dependency 'ransack'
+  spec.add_development_dependency 'railties', ENV['RAILS_VERSION']
+  spec.add_development_dependency 'activerecord', ENV['RAILS_VERSION']
   spec.add_development_dependency 'sqlite3', ENV['SQLITE3_VERSION']
   spec.add_development_dependency 'ffaker'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/jsonapi/filtering.rb
+++ b/lib/jsonapi/filtering.rb
@@ -1,5 +1,10 @@
-require 'ransack/predicate'
-require_relative 'patches'
+begin
+  require 'active_record'
+  require 'ransack'
+  require_relative 'patches'
+rescue LoadError
+  warn('Install `ransack` gem before using `JSONAPI::Filtering`!')
+end
 
 # Filtering and sorting support
 module JSONAPI

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -47,7 +47,7 @@ module JSONAPI
         ) unless resource.is_a?(ActiveModel::Errors)
 
         errors = []
-        model = resource.instance_variable_get('@base')
+        model = resource.instance_variable_get(:@base)
 
         if respond_to?(:jsonapi_serializer_class, true)
           model_serializer = jsonapi_serializer_class(model, false)

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -56,8 +56,8 @@ module JSONAPI
         end
 
         details = {}
-        if ::Rails::VERSION::MAJOR >= 6 && ::Rails::VERSION::MINOR >= 1
-          resource.map do |error|
+        if ::Rails.gem_version >= Gem::Version.new('6.1')
+          resource.each do |error|
             attr = error.attribute
             details[attr] ||= []
             details[attr] << error.detail.merge(message: error.message)

--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -121,15 +121,13 @@ module JSONAPI
 
     # Checks if an object is a collection
     #
-    # Stolen from [JSONAPI::Serializer], instance method.
+    # Basically forwards it to a [JSONAPI::Serializer] as there's no public API
     #
     # @param resource [Object] to check
     # @param force_is_collection [NilClass] flag to overwrite
     # @return [TrueClass] upon success
     def self.is_collection?(resource, force_is_collection = nil)
-      return force_is_collection unless force_is_collection.nil?
-
-      resource.respond_to?(:size) && !resource.respond_to?(:each_pair)
+      JSONAPI::ErrorSerializer.is_collection?(resource, force_is_collection)
     end
 
     # Resolves resource serializer class

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -1,8 +1,7 @@
 require 'securerandom'
-require 'active_record'
-require 'action_controller/railtie'
-require 'jsonapi'
+require 'rails/all'
 require 'ransack'
+require 'jsonapi'
 
 Rails.logger = Logger.new(STDOUT)
 Rails.logger.level = ENV['LOG_LEVEL'] || Logger::WARN

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe NotesController, type: :request do
           .to eq(Rack::Utils::HTTP_STATUS_CODES[422])
         expect(response_json['errors'][0]['source'])
           .to eq('pointer' => '/data/relationships/user')
-        if Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1
+        if Rails.gem_version >= Gem::Version.new('6.1')
           expect(response_json['errors'][0]['detail'])
             .to eq('User must exist')
         else


### PR DESCRIPTION
## What is the current behavior?

Non-collection objects with `size` attribute are mistakenly treated as collections, causing serialization to fail (see #75).

## What is the new behavior?

Only `Enumerables` are treated as collections, cf. [the corresponding method in jsonapi-serializer](https://github.com/jsonapi-serializer/jsonapi-serializer/blob/v2.2.0/lib/fast_jsonapi/object_serializer.rb#L115).

Fixes #75.

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)

## Notes

It looks like the build may be currently failing for other reasons? 