### PR TITLE
fix: Don't require ActiveRecord

### DIFF
--- a/lib/jsonapi/filtering.rb
+++ b/lib/jsonapi/filtering.rb
@@ -1,5 +1,4 @@
 begin
-  require 'active_record'
   require 'ransack'
   require_relative 'patches'
 rescue LoadError


### PR DESCRIPTION
Updates filtering.rb to not explicitly require ActiveRecord. 

## What is the current behavior?

`ActiveRecord` is automatically required when `jsonapi` is required

## What is the new behavior?

`ActiveRecord` is no longer automatically required

For those using rails & rspec without ActiveRecord, this require statement causes rspec to fail with:  No connection pool for 'ActiveRecord::Base' found.

I can't see any explicit references to `ActiveRecord` without a `defined?` check so I believe this is safe to do.  But I'd be interested to know what behavior this is used for.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
