### PR TITLE
fix: removing empty meta and link fields if data is empty to match jsonapi-serializer behaviour

### DIFF
--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -100,7 +100,7 @@ module JSONAPI
         # If it's an empty collection, return it directly.
         many = JSONAPI::Rails.is_collection?(resource, options[:is_collection])
         if many && !resource.any?
-          return options.slice(:meta, :links).merge(data: []).to_json
+          return options.slice(:meta, :links).compact.merge(data: []).to_json
         end
 
         JSONAPI_METHODS_MAPPING.to_a[2..-1].each do |opt, method_name|


### PR DESCRIPTION
## What is the current behavior?

Currently in the rendered, if it's a collection but there aren't any resources, the `meta` and `links` fields are returned in the json, even if they are nil. However, if there are more than one resource, the `links` and `meta` data fields will be remove if they are nil. 

## What is the new behavior?

Now we'll be removing any `links` or `meta` fields from the json if they are nil, if there aren't any resources. This matches how the serializer in jsonapi-serializer work so it's keeping behaviour consistent.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
