### PR TITLE
lazy load ransack fix #84

### DIFF
--- a/jsonapi.rb.gemspec
+++ b/jsonapi.rb.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.files        += %w(LICENSE.txt README.md)
   spec.require_paths = ['lib']
 
+  spec.post_install_message = 'Install `ransack` gem before using `JSONAPI::Filtering`!'
+
   spec.add_dependency 'jsonapi-serializer'
   spec.add_dependency 'rack'
 

--- a/lib/jsonapi/filtering.rb
+++ b/lib/jsonapi/filtering.rb
@@ -1,10 +1,4 @@
-begin
-  require 'active_record'
-  require 'ransack'
-  require_relative 'patches'
-rescue LoadError
-  warn('Install `ransack` gem before using `JSONAPI::Filtering`!')
-end
+require 'active_record'
 
 # Filtering and sorting support
 module JSONAPI
@@ -14,6 +8,10 @@ module JSONAPI
     # @param requested_field [String] the field to parse
     # @return [Array] with the fields and the predicate
     def self.extract_attributes_and_predicates(requested_field)
+      # lazy load ransack to be optional if not used
+      require 'ransack'
+      require_relative 'patches'
+
       predicates = []
       field_name = requested_field.to_s.dup
 


### PR DESCRIPTION
## What is the current behavior?

we have a warning when this file is loaded by jsonapi.rb gem

## What is the new behavior?

- we log during install that ransack must be installed to be able to use filtering
- we lazy load ransack to not polute logs at run time if filtering is not used

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
