### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,13 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, '3.0', '3.1']
+        ruby: [2.6, '3.0', '3.1', 3.2]
         rails: [6, 7]
         exclude:
           - ruby: '2.6'
             rails: 7
+          - ruby: 3.2
+            rails: 6
 
     steps:
     - uses: actions/checkout@v3

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rubocop/rake_task'
 require 'yaml'
 require 'yardstick'
 
+# rubocop:disable Rails/RakeEnvironment
 desc('Documentation stats and measurements')
 task('qa:docs') do
   yaml = YAML.load_file(File.expand_path('../.yardstick.yml', __FILE__))
@@ -13,6 +14,7 @@ task('qa:docs') do
   coverage = Yardstick.round_percentage(measure.coverage * 100)
   exit(1) if coverage < config.threshold
 end
+# rubocop:enable Rails/RakeEnvironment
 
 desc('Codestyle check and linter')
 RuboCop::RakeTask.new('qa:code') do |task|

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe UsersController, type: :request do
               page: { number: 2, size: 1 },
               sort: '-created_at',
               as_list: as_list
-            }.reject { |_k, _v| _v.blank? }
+            }.compact_blank
           end
 
           context 'on an array of resources' do
@@ -157,7 +157,7 @@ RSpec.describe UsersController, type: :request do
             {
               page: { number: 5, size: 1 },
               as_list: as_list
-            }.reject { |_k, _v| _v.blank? }
+            }.compact_blank
           end
 
           context 'on an array of resources' do


### PR DESCRIPTION
## What is the current behavior?

Ruby 3.2 is not in the CI matrix.
CI builds fail because of Rubocop lints

## What is the new behavior?

Ruby 3.2 is in the CI matrix.
Rubocop passes on CI builds

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [X] All automated checks pass (CI/CD)
