### PR TITLE
Allow decorating objects after pagination

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rubocop/rake_task'
 require 'yaml'
 require 'yardstick'
 
+# rubocop:disable Rails/RakeEnvironment
 desc('Documentation stats and measurements')
 task('qa:docs') do
   yaml = YAML.load_file(File.expand_path('../.yardstick.yml', __FILE__))
@@ -13,6 +14,7 @@ task('qa:docs') do
   coverage = Yardstick.round_percentage(measure.coverage * 100)
   exit(1) if coverage < config.threshold
 end
+# rubocop:enable Rails/RakeEnvironment
 
 desc('Codestyle check and linter')
 RuboCop::RakeTask.new('qa:code') do |task|

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -113,6 +113,7 @@ class UsersController < ActionController::Base
       result = result.to_a if params[:as_list]
 
       jsonapi_paginate(result) do |paginated|
+        paginated = paginated.to_a if params[:decorate_after_pagination]
         render jsonapi: paginated
       end
     end

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -30,12 +30,28 @@ end
 
 class User < ActiveRecord::Base
   has_many :notes
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(created_at first_name id last_name updated_at)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(notes)
+  end
 end
 
 class Note < ActiveRecord::Base
   validates_format_of :title, without: /BAD_TITLE/
   validates_numericality_of :quantity, less_than: 100, if: :quantity?
   belongs_to :user, required: true
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(user)
+  end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(created_at id quantity title updated_at user_id)
+  end
 end
 
 class CustomNoteSerializer

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -53,16 +53,37 @@ RSpec.describe UsersController, type: :request do
 
         context 'on page 2 out of 3' do
           let(:as_list) { }
+          let(:decorate_after_pagination) { }
           let(:params) do
             {
               page: { number: 2, size: 1 },
               sort: '-created_at',
-              as_list: as_list
+              as_list: as_list,
+              decorate_after_pagination: decorate_after_pagination
             }.compact_blank
           end
 
           context 'on an array of resources' do
             let(:as_list) { true }
+
+            it do
+              expect(response).to have_http_status(:ok)
+              expect(response_json['data'].size).to eq(1)
+              expect(response_json['data'][0]).to have_id(second_user.id.to_s)
+
+              expect(response_json['meta']['pagination']).to eq(
+                'current' => 2,
+                'first' => 1,
+                'prev' => 1,
+                'next' => 3,
+                'last' => 3,
+                'records' => 3
+              )
+            end
+          end
+
+          context 'when decorating objects after pagination' do
+            let(:decorate_after_pagination) { true }
 
             it do
               expect(response).to have_http_status(:ok)

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe UsersController, type: :request do
               page: { number: 2, size: 1 },
               sort: '-created_at',
               as_list: as_list
-            }.reject { |_k, _v| _v.blank? }
+            }.compact_blank
           end
 
           context 'on an array of resources' do
@@ -157,7 +157,7 @@ RSpec.describe UsersController, type: :request do
             {
               page: { number: 5, size: 1 },
               as_list: as_list
-            }.reject { |_k, _v| _v.blank? }
+            }.compact_blank
           end
 
           context 'on an array of resources' do


### PR DESCRIPTION
This simplification allows decorating objects after they are paginated, without losing the correct total object count.

I'm using an instance variable on the including controller here, because the decorating the paginated collection will have us lose the instance variable we set on it.

Here's the case where this happens: We have a complex ActiveRecord collection that we run through Ransack and Kaminari, but before rendering we want to convert each object in it using a `SimpleDelegator`.

Here's a simplified version of the controller action we're looking at:

```
  class UserDecorator < SimpleDelegator
    def fantastic_for_rendering
      "Whoah"
    end
  end

  def index
    allowed_fields = [
      :first_name, :last_name, :created_at,
      :notes_created_at, :notes_quantity
    ]
    options = { sort_with_expressions: true }

    jsonapi_filter(User.all, allowed_fields, options) do |filtered|
      result = filtered.result
      jsonapi_paginate(result) do |paginated|
        paginated = paginated.map { |user| UserDecorator.new() }
        render jsonapi: paginated
      end
    end
  end
```

## What is the current behavior?

When modifying objects after they are paginated, we lose the total count and get wrong pagination information.

## What is the new behavior?

In this and other cases, we get correct pagination behaviour.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
