### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, '3.0', '3.1', 3.2]
+        ruby: [2.7, '3.0', '3.1', 3.2]
         rails: [6, 7]
         exclude:
-          - ruby: '2.6'
+          - ruby: '2.7'
             rails: 7
           - ruby: 3.2
             rails: 6

--- a/lib/jsonapi/deserialization.rb
+++ b/lib/jsonapi/deserialization.rb
@@ -65,7 +65,7 @@ module JSONAPI
         rel_name = jsonapi_inflector.singularize(assoc_name)
 
         if assoc_data.is_a?(Array)
-          parsed["#{rel_name}_ids"] = assoc_data.map { |ri| ri['id'] }.compact
+          parsed["#{rel_name}_ids"] = assoc_data.filter_map { |ri| ri['id'] }
           next
         end
 

--- a/lib/jsonapi/fetching.rb
+++ b/lib/jsonapi/fetching.rb
@@ -17,7 +17,7 @@ module JSONAPI
       end
 
       params[:fields].each do |k, v|
-        extracted[k] = v.to_s.split(',').map(&:strip).compact
+        extracted[k] = v.to_s.split(',').filter_map(&:strip)
       end
 
       extracted
@@ -29,7 +29,7 @@ module JSONAPI
     #
     # @return [Array]
     def jsonapi_include
-      params['include'].to_s.split(',').map(&:strip).compact
+      params['include'].to_s.split(',').filter_map(&:strip)
     end
   end
 end


### PR DESCRIPTION
## What is the current behavior?

Currently, builds are failing because of Rubocop complaining about three lines.

## What is the new behavior?

The build still fails because of Ransack 4 being incompatible with the library, but that's for a different PR.

## Checklist

Please make sure the following requirements are complete:

- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been reviewed and added / updated if needed (for bug fixes /
  features)~
- [x] All automated checks pass (CI/CD)
