### PR TITLE
Fix specs with Ransack 4.0

### DIFF
--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -30,12 +30,28 @@ end
 
 class User < ActiveRecord::Base
   has_many :notes
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(created_at first_name id last_name updated_at)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(notes)
+  end
 end
 
 class Note < ActiveRecord::Base
   validates_format_of :title, without: /BAD_TITLE/
   validates_numericality_of :quantity, less_than: 100, if: :quantity?
   belongs_to :user, required: true
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(user)
+  end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(created_at id quantity title updated_at user_id)
+  end
 end
 
 class CustomNoteSerializer


### PR DESCRIPTION
## What is the current behavior?

Ransack 4 requires explicitly allowlisting ransackable attributes and associations for each model. This causes the specs to fail with the most recent Ransack version. This fixes those spec failures.

## What is the new behavior?

Specs will pass. 

## Checklist

Checklist doesn't apply as this is purely a fix for the test suite. 
