### PR TITLE
Issue 90 let code be in error response

### DIFF
--- a/lib/jsonapi/error_serializer.rb
+++ b/lib/jsonapi/error_serializer.rb
@@ -8,8 +8,9 @@ module JSONAPI
     set_type :error
 
     # Object/Hash attribute helpers.
-    [:status, :source, :title, :detail].each do |attr_name|
+    [:status, :source, :title, :detail, :code].each do |attr_name|
       attribute attr_name do |object|
+          binding.pry
         object.try(attr_name) || object.try(:fetch, attr_name, nil)
       end
     end

--- a/lib/jsonapi/error_serializer.rb
+++ b/lib/jsonapi/error_serializer.rb
@@ -10,7 +10,6 @@ module JSONAPI
     # Object/Hash attribute helpers.
     [:status, :source, :title, :detail, :code].each do |attr_name|
       attribute attr_name do |object|
-          binding.pry
         object.try(attr_name) || object.try(:fetch, attr_name, nil)
       end
     end

--- a/lib/jsonapi/version.rb
+++ b/lib/jsonapi/version.rb
@@ -1,3 +1,3 @@
 module JSONAPI
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -69,6 +69,7 @@ class Dummy < Rails::Application
     scope defaults: { format: :jsonapi } do
       resources :users, only: [:index]
       resources :notes, only: [:update]
+      resources :basics, only: [:index]
     end
   end
 end
@@ -158,5 +159,11 @@ class NotesController < ActionController::Base
 
   def jsonapi_meta(resources)
     { single: true }
+  end
+end
+
+class BasicsController < ActionController::Base
+  def index
+    render jsonapi_errors: { status: 422, detail: "detail", title: 'title', source: "source", code: "code" }, status: :unprocessable_entity
   end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe NotesController, type: :request do
+  describe 'GET /basic' do
+    before do
+      get(basics_path)
+    end
+
+    it do
+      expect(response_json['errors'].first.keys).to contain_exactly('status', 'source', 'title', 'detail', 'code')
+    end
+  end
+
   describe 'PUT /notes/:id' do
     let(:note) { create_note }
     let(:note_id) { note.id }


### PR DESCRIPTION
## What is the current behavior?

code is not included when using the `jsonapi_errors` renderer

## What is the new behavior?

code is included when using `render jsonapi_errors`

## Checklist

I couldn't actually run the tests with a clean checkout from master on 2.0.1.

Also I don't see any tests for `render jsonapi_errors`? maybe I'm missing it...

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
