### PR TITLE
Dummy App: Add Ransack safelists

### DIFF
--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -30,12 +30,28 @@ end
 
 class User < ActiveRecord::Base
   has_many :notes
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["last_name", "first_name", "created_at"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["notes"]
+  end
 end
 
 class Note < ActiveRecord::Base
   validates_format_of :title, without: /BAD_TITLE/
   validates_numericality_of :quantity, less_than: 100, if: :quantity?
   belongs_to :user, required: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["quantity", "created_at"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["user"]
+  end
 end
 
 class CustomNoteSerializer


### PR DESCRIPTION
Ransack 4 requires safelists for ransackable attributes on all ransacked models. This PR adds them, makind the tests run again.

## What is the current behavior?

The test suite fails.

## What is the new behavior?

The test suite does not fail.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] All automated checks pass (CI/CD)
