### PR TITLE
CI Matrix: Drop Rails 6, Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.7, '3.0', '3.1', 3.2]
-        rails: [6, '7.0', '7.1']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+        rails: ['6.1', '7.0', '7.1']
         exclude:
           - ruby: 3.2
             rails: 6


### PR DESCRIPTION


## What is the current behavior?

The CI runs fail because Ransack 4.1, which we need for Rails 7 support, is not available for Ruby < 3.0

## What is the new behavior?

The CI runs do not fail, and we test newer Rubies.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
