### PR TITLE
JSONAPI::Filtering: remove activerecord dependency

### DIFF
--- a/lib/jsonapi/filtering.rb
+++ b/lib/jsonapi/filtering.rb
@@ -1,6 +1,5 @@
 begin
-  require 'active_record'
-  require 'ransack'
+  require 'ransack/predicate'
   require_relative 'patches'
 rescue LoadError
 end


### PR DESCRIPTION
## What is the current behavior?

https://github.com/stas/jsonapi.rb/issues/101

## What is the new behavior?

Skipped requiring active record since it's a soft dependency not used directly.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
