### PR TITLE
JSONAPI::ActiveModelErrorSerializer Enhancements

### DIFF
--- a/lib/jsonapi/rails.rb
+++ b/lib/jsonapi/rails.rb
@@ -79,7 +79,11 @@ module JSONAPI
 
         JSONAPI::Rails.serializer_to_json(
           JSONAPI::ActiveModelErrorSerializer.new(
-            errors, params: { model: model, model_serializer: model_serializer }
+            errors, params: {
+              model:            model,
+              model_serializer: model_serializer,
+              status:           options[:status]
+            }
           )
         )
       end


### PR DESCRIPTION
This PR brings https://github.com/stas/jsonapi.rb/pull/45 up to date, dropping the [previous error handling changes](https://github.com/stas/jsonapi.rb/pull/45#discussion_r604774279) now that this library has dropped support for Rails < 6.

## What is the current behavior?

## What is the new behavior?

- Accept a response status provided to the error render.
- Fix the source pointer for errors on the model's base.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
