### PR TITLE
Add links attribute and gem setup fixes

### DIFF
--- a/lib/jsonapi/active_model_error_serializer.rb
+++ b/lib/jsonapi/active_model_error_serializer.rb
@@ -15,6 +15,10 @@ module JSONAPI
       object.type.to_s.delete("''").parameterize.tr('-', '_')
     end
 
+    attribute :links do
+      { "service-doc": 'https://example.com/docs' }
+    end
+
     attribute :detail do |object, _params|
       object.full_message
     end

--- a/lib/jsonapi/error_serializer.rb
+++ b/lib/jsonapi/error_serializer.rb
@@ -8,7 +8,7 @@ module JSONAPI
     set_type :error
 
     # Object/Hash attribute helpers.
-    [:status, :source, :title, :detail, :code].each do |attr_name|
+    [:status, :source, :title, :detail, :code, :links].each do |attr_name|
       attribute attr_name do |object|
         object.try(attr_name) || object.try(:fetch, attr_name, nil)
       end

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -84,7 +84,7 @@ class UserSerializer
 end
 
 class Dummy < Rails::Application
-  secrets.secret_key_base = '_'
+  config.secret_key_base = '_'
   config.hosts << 'www.example.com' if config.respond_to?(:hosts)
 
   routes.draw do

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -36,9 +36,10 @@ RSpec.describe NotesController, type: :request do
           {
             'status' => '422',
             'source' => { 'pointer' => '' },
-            'title' => 'Unprocessable Entity',
+            'title' =>  match(/Unprocessable (Entity|Content)/),
             'detail' => nil,
-            'code' => nil
+            'code' => nil,
+            'links' => nil
           }
         )
       end
@@ -63,9 +64,10 @@ RSpec.describe NotesController, type: :request do
           {
             'status' => '422',
             'source' => { 'pointer' => '/data/relationships/user' },
-            'title' => 'Unprocessable Entity',
+            'title' =>  match(/Unprocessable (Entity|Content)/),
             'detail' => expected_detail,
-            'code' => 'blank'
+            'code' => 'blank',
+            'links' => { 'service-doc' => 'https://example.com/docs' }
           }
         )
       end
@@ -85,23 +87,26 @@ RSpec.describe NotesController, type: :request do
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/title' },
-              'title' => 'Unprocessable Entity',
+              'title' =>  match(/Unprocessable (Entity|Content)/),
               'detail' => 'Title is invalid',
-              'code' => 'invalid'
+              'code' => 'invalid',
+              'links' => { 'service-doc' => 'https://example.com/docs' }
             },
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/title' },
-              'title' => 'Unprocessable Entity',
+              'title' =>  match(/Unprocessable (Entity|Content)/),
               'detail' => 'Title has typos',
-              'code' => 'invalid'
+              'code' => 'invalid',
+              'links' => { 'service-doc' => 'https://example.com/docs' }
             },
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/quantity' },
-              'title' => 'Unprocessable Entity',
+              'title' =>  match(/Unprocessable (Entity|Content)/),
               'detail' => 'Quantity must be less than 100',
-              'code' => 'less_than'
+              'code' => 'less_than',
+              'links' => { 'service-doc' => 'https://example.com/docs' }
             }
           )
         end
@@ -121,9 +126,10 @@ RSpec.describe NotesController, type: :request do
             {
               'status' => '422',
               'source' => { 'pointer' => '' },
-              'title' => 'Unprocessable Entity',
+              'title' =>  match(/Unprocessable (Entity|Content)/),
               'detail' => 'Title has slurs',
-              'code' => 'title_has_slurs'
+              'code' => 'title_has_slurs',
+              'links' => { 'service-doc' => 'https://example.com/docs' }
             }
           )
         end
@@ -144,9 +150,10 @@ RSpec.describe NotesController, type: :request do
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/title' },
-              'title' => 'Unprocessable Entity',
+              'title' =>  match(/Unprocessable (Entity|Content)/),
               'detail' => nil,
-              'code' => nil
+              'code' => nil,
+              'links' => nil
             }
           )
         end
@@ -166,7 +173,8 @@ RSpec.describe NotesController, type: :request do
             'source' => nil,
             'title' => 'Not Found',
             'detail' => nil,
-            'code' => nil
+            'code' => nil,
+            'links' => nil
           }
         )
       end
@@ -185,7 +193,8 @@ RSpec.describe NotesController, type: :request do
             'source' => nil,
             'title' => 'Internal Server Error',
             'detail' => nil,
-            'code' => nil
+            'code' => nil,
+            'links' => nil
           }
         )
       end


### PR DESCRIPTION
## What is the current behavior?

1. Unable to run gem specs after the initial bundle install.
2. Specs fail after executing `bundle exec rake spec`.
3. Missing `links` attributes as per JSON:API Specification.

## What is the new behavior?

### 1. Solved an issue with Rails `secret_key_base` config

I couldn't find any mention of `secrets` or `secrets.yml` in the project, and it also doesn't have an encrypted secrets file ([credentials](https://edgeguides.rubyonrails.org/security.html#custom-credentials), `secrets.yml.enc`), any `.env` file or a in instruction on README to add the expect ENV var. Because of this, every time I tried to run the project, I encountered the following error:

```ruby
An error occurred while loading spec_helper.
Failure/Error: secrets.secret_key_base = '_'

NameError:
  undefined local variable or method `secrets' for class Dummy
# ./spec/dummy.rb:87:in `<class:Dummy>'
# ./spec/dummy.rb:86:in `<top (required)>'
# ./spec/spec_helper.rb:10:in `<top (required)>'
No examples found.
No examples found.


Finished in 0.00003 seconds (files took 1.09 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

Finished in 0.00003 seconds (files took 1.09 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

To address this, I updated the configuration to match what the [Rails::Application](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base) object expects. Now, the specs and gem setup work correctly, allowing the tests and QA rake tasks to run as expected without any additional changes.

### 2. Resolved an Issue with the 422 Error Description

The Rack [utils.rb](https://github.com/rack/rack/blob/main/lib/rack/utils.rb#L539) defines the HTTP 422 error as Unprocessable Content, but the specs expect it to be Unprocessable Entity. I'm not entirely sure which is correct, but according to the specification, it should be [Unprocessable Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422). In any case, I've updated the specs to accept both.

### 3. Added `links` Attribute in `ErrorSerializer`

I implemented a monkey patch in my app to provide this attribute, but I believe it should be included by default, similar to how the `code` attribute was previously added. Here's the specification reference for this attribute:

- [Error Objects](https://jsonapi.org/format/#error-objects)
- [Document Links](https://jsonapi.org/format/#document-links)

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
