### PR TITLE
Updates specs to run on newer ruby versions, adds CGI.unescape to request.fullpath

### DIFF
--- a/jsonapi.rb.gemspec
+++ b/jsonapi.rb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ransack'
   spec.add_development_dependency 'railties', ENV['RAILS_VERSION']
   spec.add_development_dependency 'activerecord', ENV['RAILS_VERSION']
-  spec.add_development_dependency 'sqlite3', '~> 1.7'
+  spec.add_development_dependency 'sqlite3', '~> 2.1'
   spec.add_development_dependency 'ffaker'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'

--- a/lib/jsonapi/errors.rb
+++ b/lib/jsonapi/errors.rb
@@ -47,7 +47,7 @@ module JSONAPI
       render jsonapi_errors: [error], status: :not_found
     end
 
-    # Unprocessable entity (422) error handler callback
+    # Unprocessable Content (422) error handler callback
     #
     # @param exception [Exception] instance to handle
     # @return [String] JSONAPI error response

--- a/lib/jsonapi/pagination.rb
+++ b/lib/jsonapi/pagination.rb
@@ -29,7 +29,7 @@ module JSONAPI
     #
     # @return [Array]
     def jsonapi_pagination(resources)
-      links = { self: request.base_url + request.fullpath }
+      links = { self: request.base_url + CGI.unescape(request.fullpath) }
       pagination = jsonapi_pagination_meta(resources)
 
       return links if pagination.blank?

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -84,7 +84,6 @@ class UserSerializer
 end
 
 class Dummy < Rails::Application
-  secrets.secret_key_base = '_'
   config.hosts << 'www.example.com' if config.respond_to?(:hosts)
 
   routes.draw do

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe NotesController, type: :request do
           {
             'status' => '422',
             'source' => { 'pointer' => '' },
-            'title' => 'Unprocessable Entity',
+            'title' => 'Unprocessable Content',
             'detail' => nil,
             'code' => nil
           }
@@ -63,7 +63,7 @@ RSpec.describe NotesController, type: :request do
           {
             'status' => '422',
             'source' => { 'pointer' => '/data/relationships/user' },
-            'title' => 'Unprocessable Entity',
+            'title' => 'Unprocessable Content',
             'detail' => expected_detail,
             'code' => 'blank'
           }
@@ -85,21 +85,21 @@ RSpec.describe NotesController, type: :request do
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/title' },
-              'title' => 'Unprocessable Entity',
+              'title' => 'Unprocessable Content',
               'detail' => 'Title is invalid',
               'code' => 'invalid'
             },
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/title' },
-              'title' => 'Unprocessable Entity',
+              'title' => 'Unprocessable Content',
               'detail' => 'Title has typos',
               'code' => 'invalid'
             },
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/quantity' },
-              'title' => 'Unprocessable Entity',
+              'title' => 'Unprocessable Content',
               'detail' => 'Quantity must be less than 100',
               'code' => 'less_than'
             }
@@ -121,7 +121,7 @@ RSpec.describe NotesController, type: :request do
             {
               'status' => '422',
               'source' => { 'pointer' => '' },
-              'title' => 'Unprocessable Entity',
+              'title' => 'Unprocessable Content',
               'detail' => 'Title has slurs',
               'code' => 'title_has_slurs'
             }
@@ -144,7 +144,7 @@ RSpec.describe NotesController, type: :request do
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/title' },
-              'title' => 'Unprocessable Entity',
+              'title' => 'Unprocessable Content',
               'detail' => nil,
               'code' => nil
             }


### PR DESCRIPTION
## What is the current behaviour?

* Currently the specs do not run on Ruby versions 3.3.x and 3.4.x. 
* Pagination meta links in responses will return an escaped self link if this was passed into the request. (The other links in the meta data will be unescaped.)

## What is the new behaviour?

* Specs now run on newer Ruby versions
* Unescape request.fullpath to match output from other pagination methods

## Checklist

Please make sure the following requirements are complete:

- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ x ] All automated checks pass (CI/CD)
