### PR TITLE
Add meta field to error serializer

### DIFF
--- a/lib/jsonapi/error_serializer.rb
+++ b/lib/jsonapi/error_serializer.rb
@@ -8,7 +8,7 @@ module JSONAPI
     set_type :error
 
     # Object/Hash attribute helpers.
-    [:status, :source, :title, :detail, :code].each do |attr_name|
+    [:status, :source, :title, :detail, :code, :meta].each do |attr_name|
       attribute attr_name do |object|
         object.try(attr_name) || object.try(:fetch, attr_name, nil)
       end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe NotesController, type: :request do
             'source' => { 'pointer' => '' },
             'title' => 'Unprocessable Entity',
             'detail' => nil,
-            'code' => nil
+            'code' => nil,
+            'meta' => nil
           }
         )
       end
@@ -65,7 +66,8 @@ RSpec.describe NotesController, type: :request do
             'source' => { 'pointer' => '/data/relationships/user' },
             'title' => 'Unprocessable Entity',
             'detail' => expected_detail,
-            'code' => 'blank'
+            'code' => 'blank',
+            'meta' => nil
           }
         )
       end
@@ -87,21 +89,24 @@ RSpec.describe NotesController, type: :request do
               'source' => { 'pointer' => '/data/attributes/title' },
               'title' => 'Unprocessable Entity',
               'detail' => 'Title is invalid',
-              'code' => 'invalid'
+              'code' => 'invalid',
+              'meta' => nil
             },
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/title' },
               'title' => 'Unprocessable Entity',
               'detail' => 'Title has typos',
-              'code' => 'invalid'
+              'code' => 'invalid',
+              'meta' => nil
             },
             {
               'status' => '422',
               'source' => { 'pointer' => '/data/attributes/quantity' },
               'title' => 'Unprocessable Entity',
               'detail' => 'Quantity must be less than 100',
-              'code' => 'less_than'
+              'code' => 'less_than',
+              'meta' => nil
             }
           )
         end
@@ -123,7 +128,8 @@ RSpec.describe NotesController, type: :request do
               'source' => { 'pointer' => '' },
               'title' => 'Unprocessable Entity',
               'detail' => 'Title has slurs',
-              'code' => 'title_has_slurs'
+              'code' => 'title_has_slurs',
+              'meta' => nil
             }
           )
         end
@@ -146,7 +152,8 @@ RSpec.describe NotesController, type: :request do
               'source' => { 'pointer' => '/data/attributes/title' },
               'title' => 'Unprocessable Entity',
               'detail' => nil,
-              'code' => nil
+              'code' => nil,
+              'meta' => nil
             }
           )
         end
@@ -166,7 +173,8 @@ RSpec.describe NotesController, type: :request do
             'source' => nil,
             'title' => 'Not Found',
             'detail' => nil,
-            'code' => nil
+            'code' => nil,
+            'meta' => nil
           }
         )
       end
@@ -185,7 +193,8 @@ RSpec.describe NotesController, type: :request do
             'source' => nil,
             'title' => 'Internal Server Error',
             'detail' => nil,
-            'code' => nil
+            'code' => nil,
+            'meta' => nil
           }
         )
       end


### PR DESCRIPTION
## What is the current behavior?

The error serializer does not include the optional `meta` field when serializing JSON:API error objects.

## What is the new behavior?

The `meta` field is included when serializing error objects. See https://jsonapi.org/format/#error-objects

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
