### PR TITLE
do not make visit_Ransack_Nodes_Sort method private in patches.rb

### DIFF
--- a/lib/jsonapi/patches.rb
+++ b/lib/jsonapi/patches.rb
@@ -36,7 +36,6 @@ end
 Ransack::Visitor.class_eval do
   alias_method :original_visit_Ransack_Nodes_Sort, :visit_Ransack_Nodes_Sort
 
-  private
   # Original method assumes sorting is done only by attributes
   def visit_Ransack_Nodes_Sort(node)
     # Try the default sorting visitor method...


### PR DESCRIPTION
## What is the current behavior?

The method `visit_Ransack_Nodes_Sort` is made private in jsonapi/patches, but in ransack gem the [method](https://github.com/activerecord-hackery/ransack/blob/90a602a992f4e3a438d63e0fc2f7e1a0fb3acab0/lib/ransack/visitor.rb#L57) is publicly visible. This breaks some other ransack plugins like `mobility-ransack` non functional.

## What is the new behavior?

Remove private directive in patches.rb
